### PR TITLE
chore: Add environment input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The compile command used to compile the contracts.
 
 Currently the only `taquito_command` supported is originate. If this input is specified, all artifacts will be originated to a network.
 
+### `environment`
+
+This input is used to select the configured environment for `taqueria` to originate to. The default is set to `development`.
+
 ## Example usage
 
 ### Single step action

--- a/action.yml
+++ b/action.yml
@@ -1,32 +1,37 @@
 name: 'taqueria'
 description: 'Do something with taqueria'
 inputs:
-  project_directory:
-    description: 'The name of the project to create'
+  compile_command:
+    description: 'A command to compile the contracts'
     required: false
-  task:
-    description: 'The task for taqueria to run'
+  environment:
+    description: 'The environment to execute commands on. The default is "development"'
     required: false
+    default: 'development'
   plugins:
     description: 'A comma seperated list of plugins to install'
+    required: false
+  project_directory:
+    description: 'The name of the project to create'
     required: false
   sandbox_name:
     description: 'The name of the sandbox if any'
     required: false
-  compile_command:
-    description: 'A command to compile the contracts'
-    required: false
   taquito_command:
     description: 'The Taquito command to use. Currently only supports originate'
+    required: false
+  task:
+    description: 'The task for taqueria to run'
     required: false
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.project_directory }}
-    - ${{ inputs.task }}
-    - ${{ inputs.sandbox_name }}
-    - ${{ inputs.plugins }}
     - ${{ inputs.compile_command }}
+    - ${{ inputs.environment }}
+    - ${{ inputs.plugins }}
+    - ${{ inputs.project_directory }}
+    - ${{ inputs.sandbox_name }}
     - ${{ inputs.taquito_command }}
+    - ${{ inputs.task }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,17 +20,17 @@ if [ -n "$INPUT_PLUGINS" ]; then
     # for each plugin in the comma separated INPUT_PLUGINS install the plugin
     for plugin in $(echo $INPUT_PLUGINS | tr "," "\n"); do
         echo "Installing plugin $plugin"
-        taq install $plugin
+        taq install $plugin -e $INPUT_ENVIRONMENT
     done
 fi
 
 if [ -n "$INPUT_COMPILE_COMMAND" ]; then
     echo "Compiling contracts using the command $INPUT_COMPILE_COMMAND"
-    taq $INPUT_COMPILE_COMMAND
+    taq $INPUT_COMPILE_COMMAND -e $INPUT_ENVIRONMENT
 fi
 
 if [ -n "$INPUT_SANDBOX_NAME" ]; then
-    taq start sandbox $INPUT_SANDBOX_NAME
+    taq start sandbox $INPUT_SANDBOX_NAME -e $INPUT_ENVIRONMENT
 fi
 
 
@@ -39,10 +39,10 @@ if [ -n "$INPUT_TAQUITO_COMMAND" ]; then
         echo "The command $INPUT_TAQUITO_COMMAND is not supported yet. Only 'origintate' is currently supported"
         exit 1
     fi
-    taq $INPUT_TAQUITO_COMMAND
+    taq $INPUT_TAQUITO_COMMAND -e $INPUT_ENVIRONMENT
 fi
 
 if [ -n "$INPUT_TASK" ]; then
     echo "Running task: $INPUT_TASK"
-    taq $INPUT_TASK
+    taq $INPUT_TASK -e $INPUT_ENVIRONMENT
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,17 +20,17 @@ if [ -n "$INPUT_PLUGINS" ]; then
     # for each plugin in the comma separated INPUT_PLUGINS install the plugin
     for plugin in $(echo $INPUT_PLUGINS | tr "," "\n"); do
         echo "Installing plugin $plugin"
-        taq install $plugin -e $INPUT_ENVIRONMENT
+        taq install $plugin
     done
 fi
 
 if [ -n "$INPUT_COMPILE_COMMAND" ]; then
     echo "Compiling contracts using the command $INPUT_COMPILE_COMMAND"
-    taq $INPUT_COMPILE_COMMAND -e $INPUT_ENVIRONMENT
+    taq $INPUT_COMPILE_COMMAND
 fi
 
 if [ -n "$INPUT_SANDBOX_NAME" ]; then
-    taq start sandbox $INPUT_SANDBOX_NAME -e $INPUT_ENVIRONMENT
+    taq start sandbox $INPUT_SANDBOX_NAME
 fi
 
 
@@ -39,10 +39,10 @@ if [ -n "$INPUT_TAQUITO_COMMAND" ]; then
         echo "The command $INPUT_TAQUITO_COMMAND is not supported yet. Only 'origintate' is currently supported"
         exit 1
     fi
-    taq $INPUT_TAQUITO_COMMAND -e $INPUT_ENVIRONMENT
+    taq $INPUT_TAQUITO_COMMAND --env $INPUT_ENVIRONMENT
 fi
 
 if [ -n "$INPUT_TASK" ]; then
     echo "Running task: $INPUT_TASK"
-    taq $INPUT_TASK -e $INPUT_ENVIRONMENT
+    taq $INPUT_TASK
 fi


### PR DESCRIPTION
Added an input for the configured environment that Taqueria will deploy to. This input is only used with the `TAQUITO_COMMAND` input. Also did some houskeeping in the action file.