### PR TITLE
chore: update taqueria to version 0.20.2

### DIFF
--- a/.github/workflows/action-tests.yml
+++ b/.github/workflows/action-tests.yml
@@ -86,7 +86,7 @@ jobs:
         uses: ./
         with:
           project_directory: 'example-projects/hello-tacos'
-          tests: True
+          test_plugin: jest
 
       - name: upload artifacts
         uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV DENO_DIR=/deno
 COPY --from=docker:dind /usr/local/bin/docker /bin/docker
 
 # Download the Taqueria release binary for Linux to /bin/taq
-ADD https://github.com/ecadlabs/taqueria/releases/download/v0.19.2/taq-linux /bin/taq
+ADD https://github.com/ecadlabs/taqueria/releases/download/v0.20.2/taq-linux /bin/taq
 
 # Make the binary executable
 RUN chmod +x /bin/taq

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A docker action that helps simplify and standardize the use of [Taqueria](https://taqueria.io/) in GitHub workflows
 
 ## Taqueria version
-`v0.18.0`
+`v0.20.2`
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When set to true, all tests in the `tests` directory will be run using the Jest 
 ### Single step action
 ```yaml
 - name: taqueria tasks
-    uses: ecadlabs/taqueria-github-action@v0.7.0
+    uses: ecadlabs/taqueria-github-action@v0.8.0
     with:
         plugins: '@taqueria/plugin-ligo, @taqueria/plugin-flextesa, @taqueria/plugin-taquito, @taqueria/plugin-jest'
         compile_contracts: counter.jsligo
@@ -56,19 +56,19 @@ When set to true, all tests in the `tests` directory will be run using the Jest 
 ### Multiple step action
 ```yaml
 - name: compile contracts
-    uses: ecadlabs/taqueria-github-action@v0.7.0
+    uses: ecadlabs/taqueria-github-action@v0.8.0
     with:
         project_directory: 'example-projects/hello-tacos'
         compile_contracts: 'hello-tacos.mligo'
 
 - name: start local sandbox
-    uses: ecadlabs/taqueria-github-action@v0.7.0
+    uses: ecadlabs/taqueria-github-action@v0.8.0
     with:
         project_directory: 'example-projects/hello-tacos'
         sandbox_name: 'local'
 
 - name: deploy contracts
-    uses: ecadlabs/taqueria-github-action@v0.7.0
+    uses: ecadlabs/taqueria-github-action@v0.8.0
     with:
         project_directory: 'example-projects/hello-tacos'
         deploy_contracts: hello-tacos.tz

--- a/action.yml
+++ b/action.yml
@@ -26,18 +26,19 @@ inputs:
   task:
     description: 'The task for taqueria to run'
     required: false
-  tests:
-    description: 'Set to True/true to run tests. The Jest plugin needs to be installed'
+  test_plugin:
+    description: If set, taqueria will run tests with using the specified plugin. Ensure that the specified plugin is installed. These test will always be run after all other jobs.
     required: false
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - ${{ inputs.compile_contracts }}
+    - ${{ inputs.deploy_contracts }}
     - ${{ inputs.environment }}
     - ${{ inputs.plugins }}
     - ${{ inputs.project_directory }}
     - ${{ inputs.sandbox_name }}
-    - ${{ inputs.deploy_contracts }}
     - ${{ inputs.task }}
-    - ${{ inputs.tests }}
+    - ${{ inputs.test_plugin }}

--- a/contracts/counter.jsligo
+++ b/contracts/counter.jsligo
@@ -8,12 +8,12 @@ type parameter =
 type return_ = [list <operation>, storage];
 
 /* Two entrypoints */
-let add = ([store, delta] : [storage, int]) : storage => store + delta;
-let sub = ([store, delta] : [storage, int]) : storage => store - delta;
+const add = ([store, delta] : [storage, int]) : storage => store + delta;
+const sub = ([store, delta] : [storage, int]) : storage => store - delta;
 
 /* Main access point that dispatches to the entrypoints according to
    the smart contract parameter. */
-let main = ([action, store] : [parameter, storage]) : return_ => {
+const main = ([action, store] : [parameter, storage]) : return_ => {
  return [
    (list([]) as list <operation>),    // No operations
    (match (action, {

--- a/contracts/counter.jsligo
+++ b/contracts/counter.jsligo
@@ -21,4 +21,4 @@ const main = ([action, store] : [parameter, storage]) : return_ => {
     Decrement: (n: int) => sub ([store, n]),
     Reset:     ()  => 0}))
   ]
-}
+};

--- a/contracts/counter.storages.jsligo
+++ b/contracts/counter.storages.jsligo
@@ -2,4 +2,4 @@
 
 // Define storage variable
 
-let storage:storage = 42
+const storage:storage = 42

--- a/contracts/counter.storages.jsligo
+++ b/contracts/counter.storages.jsligo
@@ -2,4 +2,4 @@
 
 // Define storage variable
 
-const storage:storage = 42
+const storage:storage = 42;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,9 +59,10 @@ if [ -n "$INPUT_TASK" ] && [ "$INPUT_TASK" != "init" ]; then
     taq $INPUT_TASK
 fi
 
-if [ "$INPUT_TESTS" == "true" ] || [ "$INPUT_TESTS" == "True" ]; then
+if [ -n "$INPUT_TEST_PLUGIN" ]; then
     chmod -R 777 ./.taq
-    taq test
+    echo "Running tests using plugin $INPUT_TEST_PLUGIN"
+    taq test --plugin $INPUT_TEST_PLUGIN
     exit_code=$?
     chmod -R 755 ./.taq
     exit $exit_code


### PR DESCRIPTION
The GitHub action needs to be refactored after the last release of Taqueria. The new release of the action caters for the inclusion of a `--plugin` flag when running `taq test`. There are now multiple `test` commands and depending on the plugin will run different tests. For more information please see the explanation by @mweichert 

https://ecadlabs.slack.com/archives/C036G3SVA4Q/p1664823963611739